### PR TITLE
Migrate from GitHub Pages to Cloudflare Pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ TanStack Router（コードベース）。ルート定義は `src/app/router.tsx
 
 ## デプロイ
 
-GitHub Pages（`base: '/winningpost10-manager/'`）。Vite config と TanStack Router の basepath の両方に設定済み。
+Cloudflare Pages。Vite config の `base` と TanStack Router の `basepath` は `/` に設定。
 
 ## テスト
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: 'html',
   use: {
-    baseURL: 'http://localhost:5173/winningpost10-manager/',
+    baseURL: 'http://localhost:5173/',
     trace: 'on-first-retry',
   },
   projects: [
@@ -19,7 +19,7 @@ export default defineConfig({
   ],
   webServer: {
     command: 'pnpm dev',
-    url: 'http://localhost:5173/winningpost10-manager/',
+    url: 'http://localhost:5173/',
     reuseExistingServer: !process.env.CI,
   },
 });

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -86,7 +86,7 @@ const routeTree = rootRoute.addChildren([
 
 export const router = createRouter({
   routeTree,
-  basepath: '/winningpost10-manager',
+  basepath: '/',
 });
 
 declare module '@tanstack/react-router' {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@ import tailwindcss from '@tailwindcss/vite';
 import { resolve } from 'path';
 
 export default defineConfig({
-  base: '/winningpost10-manager/',
+  base: '/',
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
This PR migrates the application deployment from GitHub Pages to Cloudflare Pages by removing the `/winningpost10-manager/` base path configuration across the codebase.

## Key Changes
- **vite.config.ts**: Changed `base` from `/winningpost10-manager/` to `/`
- **src/app/router.tsx**: Updated TanStack Router `basepath` from `/winningpost10-manager` to `/`
- **playwright.config.ts**: Updated both `baseURL` and `webServer.url` from `http://localhost:5173/winningpost10-manager/` to `http://localhost:5173/`
- **CLAUDE.md**: Updated deployment documentation to reflect Cloudflare Pages instead of GitHub Pages

## Implementation Details
The application was previously deployed to a subdirectory on GitHub Pages, requiring the base path to be explicitly set in multiple configuration files. With the migration to Cloudflare Pages, the application is now deployed at the root path, simplifying the configuration and removing the need for path prefixing throughout the codebase.

https://claude.ai/code/session_01Gdm5SGHF5LVhEWK8yWvXBR